### PR TITLE
Implements embedded-hal(-async) v1.0.0-rc.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ documentation = "https://docs.rs/max31855"
 homepage = "https://github.com/cs2dsb/max31855.rs"
 
 [dependencies]
-embedded-hal = "=1.0.0-rc.3"
+embedded-hal = "1.0.0"
 bit_field    = "0.10.0"
 
 [dependencies.embedded-hal-async]
-version = "=1.0.0-rc.3"
+version = "1.0.0"
 optional = true
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "max31855"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["cs2dsb <cs2dsb@gmail.com>"]
 edition = "2018"
 description = "Driver for MAX31855 SPI thermocouple converter"
@@ -13,5 +13,14 @@ documentation = "https://docs.rs/max31855"
 homepage = "https://github.com/cs2dsb/max31855.rs"
 
 [dependencies]
-embedded-hal  = { version = "=1.0.0-rc.2" }
-bit_field     = "0.10.0"
+embedded-hal       = "=1.0.0-rc.2"
+bit_field          = "0.10.0"
+
+[dependencies.embedded-hal-async]
+version = "=1.0.0-rc.2"
+optional = true
+
+[features]
+# TODO: remove me
+default = ["async"]
+async = ["embedded-hal-async"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ documentation = "https://docs.rs/max31855"
 homepage = "https://github.com/cs2dsb/max31855.rs"
 
 [dependencies]
-embedded-hal  = { version = "0.2.3" }
+embedded-hal  = { version = "=1.0.0-rc.2" }
 bit_field     = "0.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,13 @@ documentation = "https://docs.rs/max31855"
 homepage = "https://github.com/cs2dsb/max31855.rs"
 
 [dependencies]
-embedded-hal       = "=1.0.0-rc.2"
-bit_field          = "0.10.0"
+embedded-hal = "=1.0.0-rc.2"
+bit_field    = "0.10.0"
 
 [dependencies.embedded-hal-async]
 version = "=1.0.0-rc.2"
 optional = true
 
 [features]
-# TODO: remove me
-default = ["async"]
+default = []
 async = ["embedded-hal-async"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,11 +13,11 @@ documentation = "https://docs.rs/max31855"
 homepage = "https://github.com/cs2dsb/max31855.rs"
 
 [dependencies]
-embedded-hal = "=1.0.0-rc.2"
+embedded-hal = "=1.0.0-rc.3"
 bit_field    = "0.10.0"
 
 [dependencies.embedded-hal-async]
-version = "=1.0.0-rc.2"
+version = "=1.0.0-rc.3"
 optional = true
 
 [features]

--- a/src/async_await.rs
+++ b/src/async_await.rs
@@ -2,94 +2,53 @@
 //!
 //! Intended for use with [embedded-hal-async].
 
-use embedded_hal::digital::{OutputPin, PinState};
-use embedded_hal_async::spi::{self, SpiDevice};
-
 use crate::{io_less, Error, FullResult, FullResultRaw, Unit};
-
-async fn transfer<CS, SPI>(
-    spi: &mut SPI,
-    chip_select: &mut CS,
-    buffer: &mut [u8],
-) -> Result<(), Error<SPI, CS>>
-where
-    CS: OutputPin,
-    SPI: SpiDevice<u8> + spi::ErrorType,
-{
-    chip_select
-        .set_state(PinState::Low)
-        .map_err(|e| Error::ChipSelectError(e))?;
-
-    spi.transfer_in_place(buffer)
-        .await
-        .map_err(|e| Error::SpiError(e))?;
-
-    chip_select
-        .set_state(PinState::High)
-        .map_err(|e| Error::ChipSelectError(e))
-}
+use embedded_hal_async::spi::SpiDevice;
 
 /// Trait enabling using the MAX31855
-pub trait Max31855<Spi: SpiDevice, CS: OutputPin> {
+pub trait Max31855<Spi: SpiDevice> {
     /// Reads the thermocouple temperature and leave it as a raw ADC count. Checks if there is a fault but doesn't detect what kind of fault it is
-    async fn read_thermocouple_raw(&mut self, chip_select: &mut CS) -> Result<i16, Error<Spi, CS>>;
+    async fn read_thermocouple_raw(&mut self) -> Result<i16, Error<Spi>>;
     /// Reads the thermocouple temperature and converts it into degrees in the provided unit. Checks if there is a fault but doesn't detect what kind of fault it is
-    async fn read_thermocouple(
-        &mut self,
-        chip_select: &mut CS,
-        unit: Unit,
-    ) -> Result<f32, Error<Spi, CS>>;
+    async fn read_thermocouple(&mut self, unit: Unit) -> Result<f32, Error<Spi>>;
     /// Reads both the thermocouple and the internal temperatures, leaving them as raw ADC counts and resolves faults to one of vcc short, ground short or missing thermocouple
-    async fn read_all_raw(&mut self, chip_select: &mut CS)
-        -> Result<FullResultRaw, Error<Spi, CS>>;
+    async fn read_all_raw(&mut self) -> Result<FullResultRaw, Error<Spi>>;
     /// Reads both the thermocouple and the internal temperatures, converts them into degrees in the provided unit and resolves faults to one of vcc short, ground short or missing thermocouple
-    async fn read_all(
-        &mut self,
-        chip_select: &mut CS,
-        unit: Unit,
-    ) -> Result<FullResult, Error<Spi, CS>>;
+    async fn read_all(&mut self, unit: Unit) -> Result<FullResult, Error<Spi>>;
 }
 
-impl<CS, SPI> Max31855<SPI, CS> for SPI
+impl<SPI> Max31855<SPI> for SPI
 where
-    CS: OutputPin,
     SPI: SpiDevice<u8>,
 {
     /// Reads the thermocouple temperature and leave it as a raw ADC count. Checks if there is a fault but doesn't detect what kind of fault it is
-    async fn read_thermocouple_raw(&mut self, chip_select: &mut CS) -> Result<i16, Error<SPI, CS>> {
+    async fn read_thermocouple_raw(&mut self) -> Result<i16, Error<SPI>> {
         let mut buffer = [0; 2];
-        transfer(self, chip_select, &mut buffer).await?;
+        self.transfer_in_place(&mut buffer)
+            .await
+            .map_err(Error::SpiError)?;
 
         Ok(io_less::read_thermocouple_raw(buffer)?)
     }
 
     /// Reads the thermocouple temperature and converts it into degrees in the provided unit. Checks if there is a fault but doesn't detect what kind of fault it is
-    async fn read_thermocouple(
-        &mut self,
-        chip_select: &mut CS,
-        unit: Unit,
-    ) -> Result<f32, Error<SPI, CS>> {
-        let raw = self.read_thermocouple_raw(chip_select).await?;
+    async fn read_thermocouple(&mut self, unit: Unit) -> Result<f32, Error<SPI>> {
+        let raw = self.read_thermocouple_raw().await?;
         Ok(io_less::read_thermocouple(raw, unit))
     }
 
     /// Reads both the thermocouple and the internal temperatures, leaving them as raw ADC counts and resolves faults to one of vcc short, ground short or missing thermocouple
-    async fn read_all_raw(
-        &mut self,
-        chip_select: &mut CS,
-    ) -> Result<FullResultRaw, Error<SPI, CS>> {
+    async fn read_all_raw(&mut self) -> Result<FullResultRaw, Error<SPI>> {
         let mut buffer = [0; 4];
-        transfer(self, chip_select, &mut buffer).await?;
+        self.transfer_in_place(&mut buffer)
+            .await
+            .map_err(Error::SpiError)?;
         Ok(io_less::read_all_raw(buffer)?)
     }
 
     /// Reads both the thermocouple and the internal temperatures, converts them into degrees in the provided unit and resolves faults to one of vcc short, ground short or missing thermocouple
-    async fn read_all(
-        &mut self,
-        chip_select: &mut CS,
-        unit: Unit,
-    ) -> Result<FullResult, Error<SPI, CS>> {
-        let res = self.read_all_raw(chip_select).await?;
+    async fn read_all(&mut self, unit: Unit) -> Result<FullResult, Error<SPI>> {
+        let res = self.read_all_raw().await?;
         Ok(io_less::read_all(res, unit))
     }
 }

--- a/src/async_await.rs
+++ b/src/async_await.rs
@@ -1,0 +1,134 @@
+use bit_field::BitField;
+use embedded_hal::digital::{OutputPin, PinState};
+use embedded_hal_async::spi::{self, SpiDevice};
+
+use crate::{
+    bits_to_i16, Error, FullResult, FullResultRaw, Reading, Unit, FAULT_BIT,
+    FAULT_GROUND_SHORT_BIT, FAULT_NO_THERMOCOUPLE_BIT, FAULT_VCC_SHORT_BIT, INTERNAL_BITS,
+    THERMOCOUPLE_BITS,
+};
+
+async fn transfer<CS, SPI>(
+    spi: &mut SPI,
+    chip_select: &mut CS,
+    buffer: &mut [u8],
+) -> Result<(), Error<SPI, CS>>
+where
+    CS: OutputPin,
+    SPI: SpiDevice<u8> + spi::ErrorType,
+{
+    chip_select
+        .set_state(PinState::Low)
+        .map_err(|e| Error::ChipSelectError(e))?;
+
+    spi.transfer_in_place(buffer)
+        .await
+        .map_err(|e| Error::SpiError(e))?;
+
+    chip_select
+        .set_state(PinState::High)
+        .map_err(|e| Error::ChipSelectError(e))
+}
+
+/// Trait enabling using the MAX31855
+pub trait Max31855<Spi: SpiDevice, CS: OutputPin> {
+    /// Reads the thermocouple temperature and leave it as a raw ADC count. Checks if there is a fault but doesn't detect what kind of fault it is
+    async fn read_thermocouple_raw(&mut self, chip_select: &mut CS) -> Result<i16, Error<Spi, CS>>;
+    /// Reads the thermocouple temperature and converts it into degrees in the provided unit. Checks if there is a fault but doesn't detect what kind of fault it is
+    async fn read_thermocouple(
+        &mut self,
+        chip_select: &mut CS,
+        unit: Unit,
+    ) -> Result<f32, Error<Spi, CS>>;
+    /// Reads both the thermocouple and the internal temperatures, leaving them as raw ADC counts and resolves faults to one of vcc short, ground short or missing thermocouple
+    async fn read_all_raw(&mut self, chip_select: &mut CS)
+        -> Result<FullResultRaw, Error<Spi, CS>>;
+    /// Reads both the thermocouple and the internal temperatures, converts them into degrees in the provided unit and resolves faults to one of vcc short, ground short or missing thermocouple
+    async fn read_all(
+        &mut self,
+        chip_select: &mut CS,
+        unit: Unit,
+    ) -> Result<FullResult, Error<Spi, CS>>;
+}
+
+impl<CS, SPI> Max31855<SPI, CS> for SPI
+where
+    CS: OutputPin,
+    SPI: SpiDevice<u8>,
+{
+    /// Reads the thermocouple temperature and leave it as a raw ADC count. Checks if there is a fault but doesn't detect what kind of fault it is
+    async fn read_thermocouple_raw(&mut self, chip_select: &mut CS) -> Result<i16, Error<SPI, CS>> {
+        let mut buffer = [0; 2];
+        transfer(self, chip_select, &mut buffer).await?;
+
+        if buffer[1].get_bit(FAULT_BIT) {
+            Err(Error::Fault)?
+        }
+
+        let raw = (buffer[0] as u16) << 8 | (buffer[1] as u16);
+
+        let thermocouple = bits_to_i16(raw.get_bits(THERMOCOUPLE_BITS), 14, 4, 2);
+
+        Ok(thermocouple)
+    }
+
+    /// Reads the thermocouple temperature and converts it into degrees in the provided unit. Checks if there is a fault but doesn't detect what kind of fault it is
+    async fn read_thermocouple(
+        &mut self,
+        chip_select: &mut CS,
+        unit: Unit,
+    ) -> Result<f32, Error<SPI, CS>> {
+        self.read_thermocouple_raw(chip_select)
+            .await
+            .map(|r| unit.convert(Reading::Thermocouple.convert(r)))
+    }
+
+    /// Reads both the thermocouple and the internal temperatures, leaving them as raw ADC counts and resolves faults to one of vcc short, ground short or missing thermocouple
+    async fn read_all_raw(
+        &mut self,
+        chip_select: &mut CS,
+    ) -> Result<FullResultRaw, Error<SPI, CS>> {
+        let mut buffer = [0; 4];
+        transfer(self, chip_select, &mut buffer).await?;
+
+        let fault = buffer[1].get_bit(0);
+
+        if fault {
+            let raw = (buffer[2] as u16) << 8 | (buffer[3] as u16);
+
+            if raw.get_bit(FAULT_NO_THERMOCOUPLE_BIT) {
+                Err(Error::MissingThermocoupleFault)?
+            } else if raw.get_bit(FAULT_GROUND_SHORT_BIT) {
+                Err(Error::GroundShortFault)?
+            } else if raw.get_bit(FAULT_VCC_SHORT_BIT) {
+                Err(Error::VccShortFault)?
+            } else {
+                // This should impossible, one of the other fields should be set as well
+                // but handled here just-in-case
+                Err(Error::Fault)?
+            }
+        }
+
+        let first_u16 = (buffer[0] as u16) << 8 | (buffer[1] as u16);
+        let second_u16 = (buffer[2] as u16) << 8 | (buffer[3] as u16);
+
+        let thermocouple = bits_to_i16(first_u16.get_bits(THERMOCOUPLE_BITS), 14, 4, 2);
+        let internal = bits_to_i16(second_u16.get_bits(INTERNAL_BITS), 12, 16, 4);
+
+        Ok(FullResultRaw {
+            thermocouple,
+            internal,
+        })
+    }
+
+    /// Reads both the thermocouple and the internal temperatures, converts them into degrees in the provided unit and resolves faults to one of vcc short, ground short or missing thermocouple
+    async fn read_all(
+        &mut self,
+        chip_select: &mut CS,
+        unit: Unit,
+    ) -> Result<FullResult, Error<SPI, CS>> {
+        self.read_all_raw(chip_select)
+            .await
+            .map(|r| r.convert(unit))
+    }
+}

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -1,0 +1,120 @@
+use bit_field::BitField;
+use embedded_hal::{
+    digital::{OutputPin, PinState},
+    spi::{self, SpiDevice},
+};
+
+use crate::{
+    bits_to_i16, Error, FullResult, FullResultRaw, Reading, Unit, FAULT_BIT,
+    FAULT_GROUND_SHORT_BIT, FAULT_NO_THERMOCOUPLE_BIT, FAULT_VCC_SHORT_BIT, INTERNAL_BITS,
+    THERMOCOUPLE_BITS,
+};
+
+fn transfer<CS, SPI>(
+    spi: &mut SPI,
+    chip_select: &mut CS,
+    buffer: &mut [u8],
+) -> Result<(), Error<SPI, CS>>
+where
+    CS: OutputPin,
+    SPI: SpiDevice<u8> + spi::ErrorType,
+{
+    chip_select
+        .set_state(PinState::Low)
+        .map_err(|e| Error::ChipSelectError(e))?;
+
+    spi.transfer_in_place(buffer)
+        .map_err(|e| Error::SpiError(e))?;
+
+    chip_select
+        .set_state(PinState::High)
+        .map_err(|e| Error::ChipSelectError(e))
+}
+
+/// Trait enabling using the MAX31855
+pub trait Max31855<Spi: SpiDevice, CS: OutputPin> {
+    /// Reads the thermocouple temperature and leave it as a raw ADC count. Checks if there is a fault but doesn't detect what kind of fault it is
+    fn read_thermocouple_raw(&mut self, chip_select: &mut CS) -> Result<i16, Error<Spi, CS>>;
+    /// Reads the thermocouple temperature and converts it into degrees in the provided unit. Checks if there is a fault but doesn't detect what kind of fault it is
+    fn read_thermocouple(
+        &mut self,
+        chip_select: &mut CS,
+        unit: Unit,
+    ) -> Result<f32, Error<Spi, CS>>;
+    /// Reads both the thermocouple and the internal temperatures, leaving them as raw ADC counts and resolves faults to one of vcc short, ground short or missing thermocouple
+    fn read_all_raw(&mut self, chip_select: &mut CS) -> Result<FullResultRaw, Error<Spi, CS>>;
+    /// Reads both the thermocouple and the internal temperatures, converts them into degrees in the provided unit and resolves faults to one of vcc short, ground short or missing thermocouple
+    fn read_all(&mut self, chip_select: &mut CS, unit: Unit) -> Result<FullResult, Error<Spi, CS>>;
+}
+
+impl<CS, SPI> Max31855<SPI, CS> for SPI
+where
+    CS: OutputPin,
+    SPI: SpiDevice<u8>,
+{
+    /// Reads the thermocouple temperature and leave it as a raw ADC count. Checks if there is a fault but doesn't detect what kind of fault it is
+    fn read_thermocouple_raw(&mut self, chip_select: &mut CS) -> Result<i16, Error<SPI, CS>> {
+        let mut buffer = [0; 2];
+        transfer(self, chip_select, &mut buffer)?;
+
+        if buffer[1].get_bit(FAULT_BIT) {
+            Err(Error::Fault)?
+        }
+
+        let raw = (buffer[0] as u16) << 8 | (buffer[1] as u16);
+
+        let thermocouple = bits_to_i16(raw.get_bits(THERMOCOUPLE_BITS), 14, 4, 2);
+
+        Ok(thermocouple)
+    }
+
+    /// Reads the thermocouple temperature and converts it into degrees in the provided unit. Checks if there is a fault but doesn't detect what kind of fault it is
+    fn read_thermocouple(
+        &mut self,
+        chip_select: &mut CS,
+        unit: Unit,
+    ) -> Result<f32, Error<SPI, CS>> {
+        self.read_thermocouple_raw(chip_select)
+            .map(|r| unit.convert(Reading::Thermocouple.convert(r)))
+    }
+
+    /// Reads both the thermocouple and the internal temperatures, leaving them as raw ADC counts and resolves faults to one of vcc short, ground short or missing thermocouple
+    fn read_all_raw(&mut self, chip_select: &mut CS) -> Result<FullResultRaw, Error<SPI, CS>> {
+        let mut buffer = [0; 4];
+        transfer(self, chip_select, &mut buffer)?;
+
+        let fault = buffer[1].get_bit(0);
+
+        if fault {
+            let raw = (buffer[2] as u16) << 8 | (buffer[3] as u16);
+
+            if raw.get_bit(FAULT_NO_THERMOCOUPLE_BIT) {
+                Err(Error::MissingThermocoupleFault)?
+            } else if raw.get_bit(FAULT_GROUND_SHORT_BIT) {
+                Err(Error::GroundShortFault)?
+            } else if raw.get_bit(FAULT_VCC_SHORT_BIT) {
+                Err(Error::VccShortFault)?
+            } else {
+                // This should impossible, one of the other fields should be set as well
+                // but handled here just-in-case
+                Err(Error::Fault)?
+            }
+        }
+
+        let first_u16 = (buffer[0] as u16) << 8 | (buffer[1] as u16);
+        let second_u16 = (buffer[2] as u16) << 8 | (buffer[3] as u16);
+
+        let thermocouple = bits_to_i16(first_u16.get_bits(THERMOCOUPLE_BITS), 14, 4, 2);
+        let internal = bits_to_i16(second_u16.get_bits(INTERNAL_BITS), 12, 16, 4);
+
+        Ok(FullResultRaw {
+            thermocouple,
+            internal,
+        })
+    }
+
+    /// Reads both the thermocouple and the internal temperatures, converts them into degrees in the provided unit and resolves faults to one of vcc short, ground short or missing thermocouple
+    fn read_all(&mut self, chip_select: &mut CS, unit: Unit) -> Result<FullResult, Error<SPI, CS>> {
+        self.read_all_raw(chip_select).map(|r| r.convert(unit))
+    }
+}

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -1,13 +1,14 @@
-use bit_field::BitField;
+//! A blocking (non-async) implementation of the Max31855 driver
+//!
+//! Intended for use with [embedded-hal].
+
 use embedded_hal::{
     digital::{OutputPin, PinState},
     spi::{self, SpiDevice},
 };
 
 use crate::{
-    bits_to_i16, Error, FullResult, FullResultRaw, Reading, Unit, FAULT_BIT,
-    FAULT_GROUND_SHORT_BIT, FAULT_NO_THERMOCOUPLE_BIT, FAULT_VCC_SHORT_BIT, INTERNAL_BITS,
-    THERMOCOUPLE_BITS,
+    Error, FullResult, FullResultRaw, Unit, io_less,
 };
 
 fn transfer<CS, SPI>(
@@ -57,15 +58,7 @@ where
         let mut buffer = [0; 2];
         transfer(self, chip_select, &mut buffer)?;
 
-        if buffer[1].get_bit(FAULT_BIT) {
-            Err(Error::Fault)?
-        }
-
-        let raw = (buffer[0] as u16) << 8 | (buffer[1] as u16);
-
-        let thermocouple = bits_to_i16(raw.get_bits(THERMOCOUPLE_BITS), 14, 4, 2);
-
-        Ok(thermocouple)
+        Ok(io_less::read_thermocouple_raw(buffer)?)
     }
 
     /// Reads the thermocouple temperature and converts it into degrees in the provided unit. Checks if there is a fault but doesn't detect what kind of fault it is
@@ -74,47 +67,20 @@ where
         chip_select: &mut CS,
         unit: Unit,
     ) -> Result<f32, Error<SPI, CS>> {
-        self.read_thermocouple_raw(chip_select)
-            .map(|r| unit.convert(Reading::Thermocouple.convert(r)))
+        let raw = self.read_thermocouple_raw(chip_select)?;
+        Ok(io_less::read_thermocouple(raw, unit))
     }
 
     /// Reads both the thermocouple and the internal temperatures, leaving them as raw ADC counts and resolves faults to one of vcc short, ground short or missing thermocouple
     fn read_all_raw(&mut self, chip_select: &mut CS) -> Result<FullResultRaw, Error<SPI, CS>> {
         let mut buffer = [0; 4];
         transfer(self, chip_select, &mut buffer)?;
-
-        let fault = buffer[1].get_bit(0);
-
-        if fault {
-            let raw = (buffer[2] as u16) << 8 | (buffer[3] as u16);
-
-            if raw.get_bit(FAULT_NO_THERMOCOUPLE_BIT) {
-                Err(Error::MissingThermocoupleFault)?
-            } else if raw.get_bit(FAULT_GROUND_SHORT_BIT) {
-                Err(Error::GroundShortFault)?
-            } else if raw.get_bit(FAULT_VCC_SHORT_BIT) {
-                Err(Error::VccShortFault)?
-            } else {
-                // This should impossible, one of the other fields should be set as well
-                // but handled here just-in-case
-                Err(Error::Fault)?
-            }
-        }
-
-        let first_u16 = (buffer[0] as u16) << 8 | (buffer[1] as u16);
-        let second_u16 = (buffer[2] as u16) << 8 | (buffer[3] as u16);
-
-        let thermocouple = bits_to_i16(first_u16.get_bits(THERMOCOUPLE_BITS), 14, 4, 2);
-        let internal = bits_to_i16(second_u16.get_bits(INTERNAL_BITS), 12, 16, 4);
-
-        Ok(FullResultRaw {
-            thermocouple,
-            internal,
-        })
+        Ok(io_less::read_all_raw(buffer)?)
     }
 
     /// Reads both the thermocouple and the internal temperatures, converts them into degrees in the provided unit and resolves faults to one of vcc short, ground short or missing thermocouple
     fn read_all(&mut self, chip_select: &mut CS, unit: Unit) -> Result<FullResult, Error<SPI, CS>> {
-        self.read_all_raw(chip_select).map(|r| r.convert(unit))
+        let res = self.read_all_raw(chip_select)?;
+        Ok(io_less::read_all(res, unit))
     }
 }

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -2,85 +2,51 @@
 //!
 //! Intended for use with [embedded-hal].
 
-use embedded_hal::{
-    digital::{OutputPin, PinState},
-    spi::{self, SpiDevice},
-};
-
-use crate::{
-    Error, FullResult, FullResultRaw, Unit, io_less,
-};
-
-fn transfer<CS, SPI>(
-    spi: &mut SPI,
-    chip_select: &mut CS,
-    buffer: &mut [u8],
-) -> Result<(), Error<SPI, CS>>
-where
-    CS: OutputPin,
-    SPI: SpiDevice<u8> + spi::ErrorType,
-{
-    chip_select
-        .set_state(PinState::Low)
-        .map_err(|e| Error::ChipSelectError(e))?;
-
-    spi.transfer_in_place(buffer)
-        .map_err(|e| Error::SpiError(e))?;
-
-    chip_select
-        .set_state(PinState::High)
-        .map_err(|e| Error::ChipSelectError(e))
-}
+use crate::{io_less, Error, FullResult, FullResultRaw, Unit};
+use embedded_hal::spi::SpiDevice;
 
 /// Trait enabling using the MAX31855
-pub trait Max31855<Spi: SpiDevice, CS: OutputPin> {
+pub trait Max31855<Spi: SpiDevice> {
     /// Reads the thermocouple temperature and leave it as a raw ADC count. Checks if there is a fault but doesn't detect what kind of fault it is
-    fn read_thermocouple_raw(&mut self, chip_select: &mut CS) -> Result<i16, Error<Spi, CS>>;
+    fn read_thermocouple_raw(&mut self) -> Result<i16, Error<Spi>>;
     /// Reads the thermocouple temperature and converts it into degrees in the provided unit. Checks if there is a fault but doesn't detect what kind of fault it is
-    fn read_thermocouple(
-        &mut self,
-        chip_select: &mut CS,
-        unit: Unit,
-    ) -> Result<f32, Error<Spi, CS>>;
+    fn read_thermocouple(&mut self, unit: Unit) -> Result<f32, Error<Spi>>;
     /// Reads both the thermocouple and the internal temperatures, leaving them as raw ADC counts and resolves faults to one of vcc short, ground short or missing thermocouple
-    fn read_all_raw(&mut self, chip_select: &mut CS) -> Result<FullResultRaw, Error<Spi, CS>>;
+    fn read_all_raw(&mut self) -> Result<FullResultRaw, Error<Spi>>;
     /// Reads both the thermocouple and the internal temperatures, converts them into degrees in the provided unit and resolves faults to one of vcc short, ground short or missing thermocouple
-    fn read_all(&mut self, chip_select: &mut CS, unit: Unit) -> Result<FullResult, Error<Spi, CS>>;
+    fn read_all(&mut self, unit: Unit) -> Result<FullResult, Error<Spi>>;
 }
 
-impl<CS, SPI> Max31855<SPI, CS> for SPI
+impl<SPI> Max31855<SPI> for SPI
 where
-    CS: OutputPin,
     SPI: SpiDevice<u8>,
 {
     /// Reads the thermocouple temperature and leave it as a raw ADC count. Checks if there is a fault but doesn't detect what kind of fault it is
-    fn read_thermocouple_raw(&mut self, chip_select: &mut CS) -> Result<i16, Error<SPI, CS>> {
+    fn read_thermocouple_raw(&mut self) -> Result<i16, Error<SPI>> {
         let mut buffer = [0; 2];
-        transfer(self, chip_select, &mut buffer)?;
+        self.transfer_in_place(&mut buffer)
+            .map_err(Error::SpiError)?;
 
         Ok(io_less::read_thermocouple_raw(buffer)?)
     }
 
     /// Reads the thermocouple temperature and converts it into degrees in the provided unit. Checks if there is a fault but doesn't detect what kind of fault it is
-    fn read_thermocouple(
-        &mut self,
-        chip_select: &mut CS,
-        unit: Unit,
-    ) -> Result<f32, Error<SPI, CS>> {
-        let raw = self.read_thermocouple_raw(chip_select)?;
+    fn read_thermocouple(&mut self, unit: Unit) -> Result<f32, Error<SPI>> {
+        let raw = self.read_thermocouple_raw()?;
         Ok(io_less::read_thermocouple(raw, unit))
     }
 
     /// Reads both the thermocouple and the internal temperatures, leaving them as raw ADC counts and resolves faults to one of vcc short, ground short or missing thermocouple
-    fn read_all_raw(&mut self, chip_select: &mut CS) -> Result<FullResultRaw, Error<SPI, CS>> {
+    fn read_all_raw(&mut self) -> Result<FullResultRaw, Error<SPI>> {
         let mut buffer = [0; 4];
-        transfer(self, chip_select, &mut buffer)?;
+        self.transfer_in_place(&mut buffer)
+            .map_err(Error::SpiError)?;
         Ok(io_less::read_all_raw(buffer)?)
     }
 
     /// Reads both the thermocouple and the internal temperatures, converts them into degrees in the provided unit and resolves faults to one of vcc short, ground short or missing thermocouple
-    fn read_all(&mut self, chip_select: &mut CS, unit: Unit) -> Result<FullResult, Error<SPI, CS>> {
-        let res = self.read_all_raw(chip_select)?;
+    fn read_all(&mut self, unit: Unit) -> Result<FullResult, Error<SPI>> {
+        let res = self.read_all_raw()?;
         Ok(io_less::read_all(res, unit))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@
 
 #![no_std]
 #![deny(warnings, missing_docs)]
-#![cfg_attr(feature = "async", feature(async_fn_in_trait))]
+#![cfg_attr(feature = "async", allow(async_fn_in_trait))]
 
 use bit_field::BitField;
 use core::ops::RangeInclusive;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,14 +41,20 @@
 //! ```
 
 #![no_std]
-#![deny(warnings, missing_docs)]
+// #![deny(warnings, missing_docs)]
+#![cfg_attr(feature = "async", feature(async_fn_in_trait))]
 
 use bit_field::BitField;
 use core::ops::RangeInclusive;
 use embedded_hal::{
-    digital::{self, OutputPin, PinState},
-    spi::{self, SpiDevice},
+    digital,
+    spi,
 };
+
+pub mod blocking;
+
+#[cfg(feature = "async")]
+pub mod async_await;
 
 /// The bits that represent the thermocouple value when reading the first u16 from the sensor
 const THERMOCOUPLE_BITS: RangeInclusive<usize> = 2..=15;
@@ -121,27 +127,6 @@ impl Reading {
     }
 }
 
-fn transfer<CS, SPI>(
-    spi: &mut SPI,
-    chip_select: &mut CS,
-    buffer: &mut [u8],
-) -> Result<(), Error<SPI, CS>>
-where
-    CS: OutputPin,
-    SPI: SpiDevice<u8> + spi::ErrorType,
-{
-    chip_select
-        .set_state(PinState::Low)
-        .map_err(|e| Error::ChipSelectError(e))?;
-
-    spi.transfer_in_place(buffer)
-        .map_err(|e| Error::SpiError(e))?;
-
-    chip_select
-        .set_state(PinState::High)
-        .map_err(|e| Error::ChipSelectError(e))
-}
-
 fn bits_to_i16(bits: u16, len: usize, divisor: i16, shift: usize) -> i16 {
     let negative = bits.get_bit(len - 1);
     if negative {
@@ -185,90 +170,3 @@ pub struct FullResult {
     pub unit: Unit,
 }
 
-/// Trait enabling using the MAX31855
-pub trait Max31855<Spi: SpiDevice, CS: OutputPin> {
-    /// Reads the thermocouple temperature and leave it as a raw ADC count. Checks if there is a fault but doesn't detect what kind of fault it is
-    fn read_thermocouple_raw(&mut self, chip_select: &mut CS) -> Result<i16, Error<Spi, CS>>;
-    /// Reads the thermocouple temperature and converts it into degrees in the provided unit. Checks if there is a fault but doesn't detect what kind of fault it is
-    fn read_thermocouple(
-        &mut self,
-        chip_select: &mut CS,
-        unit: Unit,
-    ) -> Result<f32, Error<Spi, CS>>;
-    /// Reads both the thermocouple and the internal temperatures, leaving them as raw ADC counts and resolves faults to one of vcc short, ground short or missing thermocouple
-    fn read_all_raw(&mut self, chip_select: &mut CS) -> Result<FullResultRaw, Error<Spi, CS>>;
-    /// Reads both the thermocouple and the internal temperatures, converts them into degrees in the provided unit and resolves faults to one of vcc short, ground short or missing thermocouple
-    fn read_all(&mut self, chip_select: &mut CS, unit: Unit) -> Result<FullResult, Error<Spi, CS>>;
-}
-
-impl<CS, SPI> Max31855<SPI, CS> for SPI
-where
-    CS: OutputPin,
-    SPI: SpiDevice<u8>,
-{
-    /// Reads the thermocouple temperature and leave it as a raw ADC count. Checks if there is a fault but doesn't detect what kind of fault it is
-    fn read_thermocouple_raw(&mut self, chip_select: &mut CS) -> Result<i16, Error<SPI, CS>> {
-        let mut buffer = [0; 2];
-        transfer(self, chip_select, &mut buffer)?;
-
-        if buffer[1].get_bit(FAULT_BIT) {
-            Err(Error::Fault)?
-        }
-
-        let raw = (buffer[0] as u16) << 8 | (buffer[1] as u16);
-
-        let thermocouple = bits_to_i16(raw.get_bits(THERMOCOUPLE_BITS), 14, 4, 2);
-
-        Ok(thermocouple)
-    }
-
-    /// Reads the thermocouple temperature and converts it into degrees in the provided unit. Checks if there is a fault but doesn't detect what kind of fault it is
-    fn read_thermocouple(
-        &mut self,
-        chip_select: &mut CS,
-        unit: Unit,
-    ) -> Result<f32, Error<SPI, CS>> {
-        self.read_thermocouple_raw(chip_select)
-            .map(|r| unit.convert(Reading::Thermocouple.convert(r)))
-    }
-
-    /// Reads both the thermocouple and the internal temperatures, leaving them as raw ADC counts and resolves faults to one of vcc short, ground short or missing thermocouple
-    fn read_all_raw(&mut self, chip_select: &mut CS) -> Result<FullResultRaw, Error<SPI, CS>> {
-        let mut buffer = [0; 4];
-        transfer(self, chip_select, &mut buffer)?;
-
-        let fault = buffer[1].get_bit(0);
-
-        if fault {
-            let raw = (buffer[2] as u16) << 8 | (buffer[3] as u16);
-
-            if raw.get_bit(FAULT_NO_THERMOCOUPLE_BIT) {
-                Err(Error::MissingThermocoupleFault)?
-            } else if raw.get_bit(FAULT_GROUND_SHORT_BIT) {
-                Err(Error::GroundShortFault)?
-            } else if raw.get_bit(FAULT_VCC_SHORT_BIT) {
-                Err(Error::VccShortFault)?
-            } else {
-                // This should impossible, one of the other fields should be set as well
-                // but handled here just-in-case
-                Err(Error::Fault)?
-            }
-        }
-
-        let first_u16 = (buffer[0] as u16) << 8 | (buffer[1] as u16);
-        let second_u16 = (buffer[2] as u16) << 8 | (buffer[3] as u16);
-
-        let thermocouple = bits_to_i16(first_u16.get_bits(THERMOCOUPLE_BITS), 14, 4, 2);
-        let internal = bits_to_i16(second_u16.get_bits(INTERNAL_BITS), 12, 16, 4);
-
-        Ok(FullResultRaw {
-            thermocouple,
-            internal,
-        })
-    }
-
-    /// Reads both the thermocouple and the internal temperatures, converts them into degrees in the provided unit and resolves faults to one of vcc short, ground short or missing thermocouple
-    fn read_all(&mut self, chip_select: &mut CS, unit: Unit) -> Result<FullResult, Error<SPI, CS>> {
-        self.read_all_raw(chip_select).map(|r| r.convert(unit))
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,15 +231,15 @@ mod io_less {
             let raw = (buffer[2] as u16) << 8 | (buffer[3] as u16);
 
             if raw.get_bit(FAULT_NO_THERMOCOUPLE_BIT) {
-                Err(IoLessError::MissingThermocoupleFault)?
+                return Err(IoLessError::MissingThermocoupleFault);
             } else if raw.get_bit(FAULT_GROUND_SHORT_BIT) {
-                Err(IoLessError::GroundShortFault)?
+                return Err(IoLessError::GroundShortFault);
             } else if raw.get_bit(FAULT_VCC_SHORT_BIT) {
-                Err(IoLessError::VccShortFault)?
+                return Err(IoLessError::VccShortFault);
             } else {
                 // This should impossible, one of the other fields should be set as well
                 // but handled here just-in-case
-                Err(IoLessError::Fault)?
+                return Err(IoLessError::Fault);
             }
         }
 


### PR DESCRIPTION
This PR implements the new embedded-hal traits.

At the moment (until 2023-12-28), async functions in trait requires a nightly feature, which is why I've moved the async support behind a feature for now.

I haven't tested this yet (waiting for actual hardware), but wanted to share in case you'd like to discuss.

Closes #3 